### PR TITLE
Create services

### DIFF
--- a/src/main/java/dev/springallergies/controllers/UserController.java
+++ b/src/main/java/dev/springallergies/controllers/UserController.java
@@ -1,7 +1,7 @@
 package dev.springallergies.controllers;
 
 import dev.springallergies.entities.User;
-import dev.springallergies.service.UserService;
+import dev.springallergies.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/dev/springallergies/repos/ItemRepo.java
+++ b/src/main/java/dev/springallergies/repos/ItemRepo.java
@@ -12,8 +12,7 @@ import java.util.List;
 @Repository
 public interface ItemRepo extends JpaRepository<Item,Integer> {
 
-    List<Item> findItemByStatus (String Status);
-    List<Item> findItemBySupplier ( String supplier);
-    List<Item> findItemByPid (int pid);
-
+    List<Item> findByStatus(String Status);
+    List<Item> findBySupplier(String supplier);
+    List<Item> findByPid(int pid);
 }

--- a/src/main/java/dev/springallergies/repos/PotlukkRepo.java
+++ b/src/main/java/dev/springallergies/repos/PotlukkRepo.java
@@ -12,6 +12,10 @@ import java.util.List;
 @Component
 @Repository
 public interface PotlukkRepo extends JpaRepository<Potlukk,Integer> {
-    List<Potlukk> findPotlukkByCreatorid(int creatorid);
-    List<Potlukk> findPotlukkByTime(BigInteger time);
+    List<Potlukk> findByCreatorid(int creatorid);
+
+    //probably unnecessary since time is probably down to the second (or less)
+    //if anything it would be the range of a day using two greater or lesser than start of date and end of date times
+    //but any case probably unnecessary but might make decent bonus functionality later
+    //List<Potlukk> findByTime(BigInteger time);
 }

--- a/src/main/java/dev/springallergies/repos/UserRepo.java
+++ b/src/main/java/dev/springallergies/repos/UserRepo.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Component
 @Repository
 public interface UserRepo extends JpaRepository<User,Integer> {
-    List<User> findUserByUserName(String username);
+    List<User> findByUserName(String username);
 }

--- a/src/main/java/dev/springallergies/services/ItemService.java
+++ b/src/main/java/dev/springallergies/services/ItemService.java
@@ -1,0 +1,22 @@
+package dev.springallergies.services;
+
+import dev.springallergies.entities.Item;
+import dev.springallergies.entities.Potlukk;
+
+import java.util.List;
+
+public interface ItemService {
+    Item fetchItemByItemId(int itemId);
+
+    List<Item> fetchItems();
+
+    List<Item> fetchItemsByPid(int userId);
+
+    List<Item> fetchItemsByStatus(String status);
+
+    List<Item> fetchItemsBySupplier(String supplier);
+
+    Item updateItem(Item updatedItem);
+
+    boolean deleteItem(Item deleteItem);
+}

--- a/src/main/java/dev/springallergies/services/ItemServiceImpl.java
+++ b/src/main/java/dev/springallergies/services/ItemServiceImpl.java
@@ -1,0 +1,89 @@
+package dev.springallergies.services;
+
+import dev.springallergies.entities.Item;
+import dev.springallergies.repos.ItemRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@Service
+public class ItemServiceImpl implements ItemService {
+
+    @Autowired
+    private ItemRepo itemRepo;
+
+    /**
+     * @param itemId item identifier to be fetched
+     * @return if found returns the associated item object otherwise return a default item object
+     */
+    @Override
+    public Item fetchItemByItemId(int itemId) {
+        Optional<Item> result = this.itemRepo.findById(itemId);
+        if (result.isPresent())
+            return result.get();
+        return new Item();
+    }
+
+    /**
+     * @return returns all items submitted
+     */
+    @Override
+    public List<Item> fetchItems() {
+        return this.itemRepo.findAll();
+    }
+
+    /**
+     * @param pid potluck id to be used as a query
+     * @return all items associated with potluck id
+     */
+    @Override
+    public List<Item> fetchItemsByPid(int pid) {
+        return this.itemRepo.findByPid(pid);
+    }
+
+    /**
+     * @param status query by status type
+     * @return returns all items with associated status
+     */
+    @Override
+    public List<Item> fetchItemsByStatus(String status) {
+        return this.itemRepo.findByStatus(status);
+    }
+
+    /**
+     * @param supplier supplier name (typically first and last name) to query by
+     * @return returns all items associated with supplier name
+     */
+    @Override
+    public List<Item> fetchItemsBySupplier(String supplier) {
+        return this.itemRepo.findBySupplier(supplier);
+    }
+
+    /**
+     * @param updatedItem item object to be updated
+     * @return updated item object
+     */
+    @Override
+    public Item updateItem(Item updatedItem) {
+        return this.itemRepo.save(updatedItem);
+    }
+
+    /**
+     * @param deleteItem item object to be deleted
+     * @return boolean based on error not being thrown if success
+     */
+    @Override
+    public boolean deleteItem(Item deleteItem) {
+        try {
+            this.itemRepo.delete(deleteItem);
+            return true;
+        } catch (Exception e) {
+
+        }
+        return false;
+    }
+}

--- a/src/main/java/dev/springallergies/services/PotluckService.java
+++ b/src/main/java/dev/springallergies/services/PotluckService.java
@@ -1,0 +1,17 @@
+package dev.springallergies.services;
+
+import dev.springallergies.entities.Potlukk;
+
+import java.util.List;
+
+public interface PotluckService {
+    Potlukk fetchPotluckByPotID(int potluckId);
+
+    List<Potlukk> fetchPotlucksByUserID(int userId);
+
+    List<Potlukk> fetchPotlucks();
+
+    Potlukk updatePotluck(Potlukk updatedPot);
+
+    boolean deletePotluck(Potlukk deletePot);
+}

--- a/src/main/java/dev/springallergies/services/PotluckServiceImpl.java
+++ b/src/main/java/dev/springallergies/services/PotluckServiceImpl.java
@@ -1,0 +1,70 @@
+package dev.springallergies.services;
+
+import dev.springallergies.entities.Potlukk;
+import dev.springallergies.repos.PotlukkRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@Service
+public class PotluckServiceImpl implements PotluckService {
+    @Autowired
+    private PotlukkRepo potlukkRepo;
+
+    /**
+     * @param potluckId identifier of a particular potluck
+     * @return returns a potluck with the corresponding potluck ID or a default potlukk object
+     */
+    @Override
+    public Potlukk fetchPotluckByPotID(int potluckId) {
+        Optional<Potlukk> result = this.potlukkRepo.findById(potluckId);
+        if (result.isPresent())
+            return result.get();
+        return new Potlukk();
+    }
+
+    /**
+     * @param userId
+     * @return returns all potlucks made by the user
+     */
+    @Override
+    public List<Potlukk> fetchPotlucksByUserID(int userId) {
+        return this.potlukkRepo.findByCreatorid(userId);
+    }
+
+    /**
+     * @return returns all potlucks
+     */
+    @Override
+    public List<Potlukk> fetchPotlucks() {
+        return this.potlukkRepo.findAll();
+    }
+
+    /**
+     * @param updatedPot potluck to be updated
+     * @return updatedPotluck Object
+     */
+    @Override
+    public Potlukk updatePotluck(Potlukk updatedPot) {
+        return this.potlukkRepo.save(updatedPot);
+    }
+
+    /**
+     * @param deletePot potluck to be removed
+     * @return boolean based on error not being thrown if success
+     */
+    @Override
+    public boolean deletePotluck(Potlukk deletePot) {
+        try {
+            this.potlukkRepo.delete(deletePot);
+            return true;
+        } catch (Exception e) {
+
+        }
+        return false;
+    }
+}

--- a/src/main/java/dev/springallergies/services/UserService.java
+++ b/src/main/java/dev/springallergies/services/UserService.java
@@ -1,13 +1,11 @@
-package dev.springallergies.service;
+package dev.springallergies.services;
 
 import dev.springallergies.entities.User;
 
 import java.util.List;
 
 public interface UserService {
-
     User registerUser(User user);
     List<User> retrieveUsers();
     User getUserByIdNo(int userId);
-
 }

--- a/src/main/java/dev/springallergies/services/UserServiceImpl.java
+++ b/src/main/java/dev/springallergies/services/UserServiceImpl.java
@@ -1,4 +1,4 @@
-package dev.springallergies.service;
+package dev.springallergies.services;
 
 import dev.springallergies.entities.User;
 import dev.springallergies.repos.UserRepo;
@@ -31,8 +31,7 @@ public class UserServiceImpl implements UserService{
         Optional<User> possibleUser = this.userRepo.findById(userId);
         if(possibleUser.isPresent()){
             return possibleUser.get();
-        }else{
-            throw new RuntimeException("No account with that user id");
         }
+        return new User();
     }
 }


### PR DESCRIPTION
modified service package name to plural. `service` => `services`

Removed Entity mentions in Repo methods as type is implied by extended JPA Repository typing
`findPotlukkByCreatorid()` => `findByCreatorid()`

commented out potlukk Repo `findByTime` as functionality doesn't make sense and would be implemented differently as it would be using LesserThan and GreaterThan to broaden the range to a time period such as a full day.  
`List<Potlukk> findByTime(BigInteger time);`